### PR TITLE
Fix dart build errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ A minimalistic, fast, and feature-rich web browser built with Flutter, designed 
 - **Modern Flutter**: Latest best practices and patterns
 - **Maintainable Code**: Clear structure and documentation
 
+### Recent Bug Fixes
+- **RegExp Syntax Error**: Fixed character class syntax errors in userscript_manager.dart
+  - Resolved `[^"\']+` pattern issues causing build failures
+  - Converted raw strings to regular strings with proper escaping
+  - Affected patterns: location.hostname, window.location.host, document.domain detection
+
 ### User Experience Enhancements
 - **Intuitive Navigation**: Natural iOS-like interaction patterns
 - **Visual Consistency**: Unified design language throughout

--- a/lib/widgets/userscript_manager.dart
+++ b/lib/widgets/userscript_manager.dart
@@ -308,9 +308,9 @@ class _AddScriptDialogState extends State<_AddScriptDialog> {
     final patterns = [
       RegExp(r'@match\s+https?://([^/\s]+)', caseSensitive: false),
       RegExp(r'@include\s+https?://([^/\s]+)', caseSensitive: false),
-      RegExp(r'location\.hostname.*["\']([^"\']+)["\']', caseSensitive: false),
-      RegExp(r'window\.location\.host.*["\']([^"\']+)["\']', caseSensitive: false),
-      RegExp(r'document\.domain.*["\']([^"\']+)["\']', caseSensitive: false),
+      RegExp('location\\.hostname.*["\']([^"\']+)["\']', caseSensitive: false),
+      RegExp('window\\.location\\.host.*["\']([^"\']+)["\']', caseSensitive: false),
+      RegExp('document\\.domain.*["\']([^"\']+)["\']', caseSensitive: false),
     ];
 
     for (final pattern in patterns) {


### PR DESCRIPTION
Fix RegExp syntax errors in `userscript_manager.dart`.

The original raw string literals `r'...'` were misinterpreting the escape sequence `\'` within character classes like `[^"\']`, leading to compilation errors. Converting them to regular string literals `'...'` and properly escaping backslashes (`\\.`) resolves these build failures.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents?id=bc-53bf9744-3c64-40bd-9338-3454e80f803b) · [Cursor](https://cursor.com/background-agent?bcId=bc-53bf9744-3c64-40bd-9338-3454e80f803b)

Refer to [Background Agent docs](https://docs.cursor.com/background-agents)